### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ A personal portfolio site built with Flask to showcase my programming projects a
 ## Contact Information
 
 - **Email**: [fprofili@outlook.com](mailto:fprofili@outlook.com)
-- **LinkedIn**: [[linkedin.com/in/fprofili/](https://www.linkedin.com/in/fprofili/)](#)
+- **LinkedIn**: [linkedin.com/in/fprofili/](https://www.linkedin.com/in/fprofili/)
 - **Pronouns**: He/Him


### PR DESCRIPTION
## Summary
- fix the malformed LinkedIn link in README.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854436e0d48832bb93dc527d1c1f28d